### PR TITLE
fix help: kind name is wrong in code examples

### DIFF
--- a/doc/ddu-source-git_branch.txt
+++ b/doc/ddu-source-git_branch.txt
@@ -48,7 +48,7 @@ Examples ~
 	    \ 'sources': [{
 	    \    'name': 'git_branch',
 	    \ }],
-	    \ 'kindOptions': { 'file': { 'defaultAction': 'switch' } }
+	    \ 'kindOptions': { 'git_branch': { 'defaultAction': 'switch' } }
 	    \ })
 <
 
@@ -60,7 +60,7 @@ Examples ~
 	    \    'name': 'git_branch',
 	    \    'options': { 'path': expand("%:p") }
 	    \ }],
-	    \ 'kindOptions': { 'file': { 'defaultAction': 'switch' } }
+	    \ 'kindOptions': { 'git_branch': { 'defaultAction': 'switch' } }
 	    \ })
 <
 
@@ -79,7 +79,7 @@ Examples ~
 	    \      ],
 	    \    },
 	    \ }],
-	    \ 'kindOptions': { 'file': { 'defaultAction': 'switch' } }
+	    \ 'kindOptions': { 'git_branch': { 'defaultAction': 'switch' } }
 	    \ })
 <
 


### PR DESCRIPTION
Now, kind target is 'file' in example configuration of doc.

I think this is mistake for 'git_branch'