### PR TITLE
fix: Default value of param-remote doesn't equal to defined in doc

### DIFF
--- a/denops/@ddu-sources/git_branch.ts
+++ b/denops/@ddu-sources/git_branch.ts
@@ -145,6 +145,6 @@ export class Source extends BaseSource<Params, ActionData> {
   }
 
   override params(): Params {
-    return { remote: true, local: true };
+    return { remote: false, local: true };
   }
 }


### PR DESCRIPTION
In documentation, |ddu-source-git_branch-param-remote|'s default value is defined to "false". But it's "true" actually.